### PR TITLE
Mac OS: build and ./mpegflow run fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 CFLAGS = -O3 -D__STDC_CONSTANT_MACROS
-LDFLAGS = -lswscale -lavdevice -lavformat -lavcodec -lswresample -lavutil -lpthread -lbz2 -lz -lc -lrt
-INSTALLED_DEPS = -Idependencies/include -Ldependencies/lib
+LDFLAGS = -lswscale -lavdevice -lavformat -lavcodec -lswresample -lavutil -lpthread -lbz2 -lz -lc -liconv -llzma
+INSTALLED_DEPS = -Idependencies/include -Ldependencies/lib -L/usr/local/lib
+FRAMEWORKS = -framework CoreMedia -framework AudioToolbox -framework CoreVideo -framework VideoToolbox -framework CoreFoundation -framework Security
 
 mpegflow: mpegflow.cpp
-	g++ $< -o $@ $(CFLAGS) $(LDFLAGS) $(INSTALLED_DEPS)
+	g++ $< -o $@ $(CFLAGS) $(LDFLAGS) $(INSTALLED_DEPS) $(FRAMEWORKS)
 
 vis: vis.cpp
 	g++ $< -o $@ $(CFLAGS) -lopencv_highgui -lopencv_videoio -lopencv_imgproc -lopencv_imgcodecs -lopencv_core -lpng $(LDFLAGS) $(INSTALLED_DEPS) 


### PR DESCRIPTION
With these fixes: 1) will build on Mac OS and 2) ./mpegflow will execute successfully, e.g.

`./mpegflow examples/mpi_sintel_final_alley_1.avi > examples/alley_1.txt`